### PR TITLE
[INSTA-34029] Fix `Illegal option -o pipefail` on `dash`

### DIFF
--- a/agent/k8s/instana-k8s-mustgather.sh
+++ b/agent/k8s/instana-k8s-mustgather.sh
@@ -13,10 +13,16 @@
 # Safer scripting:
 # -e  : exit on any command failing
 # -u  : treat unset variables as errors
-# -o pipefail : fail if any command in a pipeline fails (may not be supported on older sh)
-set -euo pipefail
+# -o pipefail : fail if any command in a pipeline fails (not supported by dash)
+SHELL_EXECUTABLE="/bin/sh"
+while IT=$(readlink "${SHELL_EXECUTABLE}"); do SHELL_EXECUTABLE="${IT}"; done
+if [ "${SHELL_EXECUTABLE##*/}" = 'dash' ]; then
+   set -eu
+else
+   set -euo pipefail
+fi
 
-VERSION="1.1.7"
+VERSION="1.1.8"
 echo "Version: ${VERSION}" >&2
 
 CURRENT_TIME=$(date "+%Y%m%d-%H%M%S")


### PR DESCRIPTION
The `pipefail` feature is independet from the age of the shell, not even the latest version of `dash` would support this option. And currently also on the latest `Ubuntu` images the `/bin/sh` used by `instana-k8s-mustgather.sh` is symlinked to `dash`:

````
podman run --rm -it ubuntu:latest ls -lah /bin/sh
lrwxrwxrwx. 1 root root 4 Mar 31  2024 /bin/sh -> dash
````

Since `Ubuntu` and `dash` are not exactly uncommon, and having to troubleshoot and edit the script in these cases is a hassle, this commit checks in runtime for this option.