### PR TITLE
mustgather: correctly detect openshift

### DIFF
--- a/agent/k8s/instana-k8s-mustgather.sh
+++ b/agent/k8s/instana-k8s-mustgather.sh
@@ -48,7 +48,7 @@ else
 fi
 
 ###############################################################################
-# Determine if we're on OpenShift (oc) or vanilla K8s (kubectl)
+# Determine if we're on OpenShift or vanilla K8s
 ###############################################################################
 if ${CMD} api-resources | grep openshift > /dev/null 2>&1; then
     LIST_NS="${INSTANA_AGENT_NAMESPACE} openshift-controller-manager"

--- a/agent/k8s/instana-k8s-mustgather.sh
+++ b/agent/k8s/instana-k8s-mustgather.sh
@@ -34,18 +34,29 @@ mkdir -p "${MGDIR}"
 ###############################################################################
 : "${INSTANA_AGENT_NAMESPACE:=instana-agent}"
 
+
 ###############################################################################
-# Determine if we're on OpenShift (oc) or vanilla K8s (kubectl)
+# Determine which tool to use (oc or kubectl)
 ###############################################################################
 if command -v oc >/dev/null 2>&1; then
     CMD="oc"
-    LIST_NS="${INSTANA_AGENT_NAMESPACE} openshift-controller-manager"
 elif command -v kubectl >/dev/null 2>&1; then
     CMD="kubectl"
-    LIST_NS="${INSTANA_AGENT_NAMESPACE}"
 else
     echo "ERROR: Neither 'oc' nor 'kubectl' is installed or in PATH." >&2
     exit 1
+fi
+
+###############################################################################
+# Determine if we're on OpenShift (oc) or vanilla K8s (kubectl)
+###############################################################################
+if ${CMD} api-resources | grep openshift > /dev/null 2>&1; then
+    LIST_NS="${INSTANA_AGENT_NAMESPACE} openshift-controller-manager"
+    OPENSHIFT=1
+    echo "Detected an Openshift cluster"
+else
+    LIST_NS="${INSTANA_AGENT_NAMESPACE}"
+    OPENSHIFT=0
 fi
 
 ###############################################################################
@@ -77,7 +88,7 @@ run_cmd "${CMD}" describe nodes > "${MGDIR}/node-describe.txt"
 run_cmd "${CMD}" get namespaces > "${MGDIR}/namespaces.txt"
 
 # If on OpenShift, gather clusteroperators
-if [ "${CMD}" = "oc" ]; then
+if [ ${OPENSHIFT} = "1" ]; then
     run_cmd "${CMD}" get clusteroperators > "${MGDIR}/cluster-operators.txt"
 fi
 
@@ -150,7 +161,7 @@ done < "${MGDIR}/instana-agent-pod-names.txt"
 ###############################################################################
 # If on OpenShift, gather pods in openshift-controller-manager namespace
 ###############################################################################
-if [ "${CMD}" = "oc" ]; then
+if [ ${OPENSHIFT} = "1" ]; then
     run_cmd "${CMD}" get pods -n openshift-controller-manager -o wide \
         > "${MGDIR}/openshift-controller-manager-pod-list.txt"
 fi


### PR DESCRIPTION
Previously it would assume we were using an Openshift Cluster if it detected the existence of `oc` command in PATH. 

This is not correct, since a user might have both `oc` and `kubectl` installed and use either one depending on the current context which it's currently in use, i.e: a given user could maintain both Openshift and non Openshift cluster with either of the cli tools.

We can detect if the context is currently one of an Openshift cluster if any of the api-resources contains an Openshift specific API.

Reference: https://jsw.ibm.com/browse/INSTA-49119