### PR TITLE
feat(INSTA-75604): Collect ETCD metric service

### DIFF
--- a/agent/k8s/README.md
+++ b/agent/k8s/README.md
@@ -106,8 +106,13 @@ instana-k8s-mustgather-VERSION-TIMESTAMP/
 ├── cluster-info_openshift_clusteroperators.txt (OpenShift only)
 ├── agent-config-<namespace>.json
 └── namespaces/
-    └── openshift-controller-manager/ (Openshift only)
-        ├── resources-and-events.txt
+    ├── openshift-controller-manager/ (Openshift only)
+    │   └── resources-and-events.txt
+    ├── kube-system/ (non-Openshift only)
+    │   └── svcs/
+    │       └── <service-name>/
+    │           ├── describe.txt
+    │           └── object-spec.yaml
     └── <namespace>/
         ├── resources-and-events.txt
         └── pods/

--- a/agent/k8s/README.md
+++ b/agent/k8s/README.md
@@ -146,6 +146,9 @@ instana-k8s-mustgather-VERSION-TIMESTAMP/
 ### Namespace Resources
 
 - All resources and events in namespaces containing Instana components
+- On OpenShift custers only, from the `openshift-controller-manager` namespace, a list of all the `pods`, `services`, `daemonsets`, `deployments`, `replicasets`, `jobs`, `cronjobs`, `statefulsets` and `events`.
+- On Non-OpenShift custers only, from the `kube-system` namespace, the `yaml` resource definition and the `describe` output of ETCD metric `services`
+  that match the [discovery criteria](https://github.com/instana/instana-agent-operator/blob/4482abf657a1b3b4e64814ce081fe933f52544a8/docs/etcd-metrics.md#vanilla-kubernetes-clusters).
 
 ### Pod Data
 

--- a/agent/k8s/instana-k8s-mustgather.sh
+++ b/agent/k8s/instana-k8s-mustgather.sh
@@ -282,8 +282,7 @@ collect_pod_data() {
 collect_etcd_metric_service() {
     log "Collecting etcd metric service definition from kube-system namespace"
 
-    etcd_dir="${MUSTGATHER_DIR}/kube-system/etcd-services"
-    make_directories "${etcd_dir}"
+    etcd_metrics_service_dir="${MUSTGATHER_DIR}/namespaces/kube-system/svcs"
 
     # Collect services with component=etcd label
     log_debug "Searching for services with label component=etcd"
@@ -312,18 +311,22 @@ collect_etcd_metric_service() {
         svc=$(echo "${svc_name}" | sed 's|^service/||')
         log_debug "Collecting definition for service: ${svc}"
 
+        # Make directory with service name
+        service_dir="${etcd_metrics_service_dir}/${svc}"
+        make_directories "${service_dir}"
+
         # Get service definition in YAML format
         ${CLI} get svc "${svc}" -n kube-system -o yaml \
-            >"${etcd_dir}/${svc}.yaml" 2>&1 ||
+            >"${service_dir}/object-spec.yaml" 2>&1 ||
             log_warn "Failed to collect definition for service ${svc}"
 
         # Get service description
         ${CLI} describe svc "${svc}" -n kube-system \
-            >"${etcd_dir}/${svc}-describe.txt" 2>&1 ||
+            >"${service_dir}/describe.txt" 2>&1 ||
             log_warn "Failed to describe service ${svc}"
     done
 
-    log "etcd service definitions collected in ${etcd_dir}"
+    log "etcd service definitions collected in ${etcd_metrics_service_dir}"
 }
 
 show_usage() {

--- a/agent/k8s/instana-k8s-mustgather.sh
+++ b/agent/k8s/instana-k8s-mustgather.sh
@@ -252,7 +252,7 @@ collect_pod_data() {
             # Copy agent logs
             ${CLI} -n "${ns}" cp "${pod}:/opt/instana/agent/data/log/" "${dump_dir}/agent-logs" 2>&1 || \
                 log_warn "Failed to copy logs from ${pod}"
-            
+
             # Run diagnostics
             for command in version check-ports check-configuration; do
                 log_debug "Running diagnostic: ${command} on ${pod}"
@@ -279,7 +279,52 @@ collect_pod_data() {
     log "Pod data collected (processed: ${processed}, skipped: ${skipped})"
 }
 
+collect_etcd_metric_service() {
+    log "Collecting etcd metric service definition from kube-system namespace"
 
+    etcd_dir="${MUSTGATHER_DIR}/kube-system/etcd-services"
+    make_directories "${etcd_dir}"
+
+    # Collect services with component=etcd label
+    log_debug "Searching for services with label component=etcd"
+    etcd_services=$(${CLI} get svc -n kube-system -l component=etcd -o name 2>/dev/null || true)
+
+    # Collect services named etcd or etcd-metrics
+    log_debug "Searching for services named etcd or etcd-metrics"
+    named_services=$(${CLI} get svc -n kube-system -o name 2>/dev/null | grep -E "/(etcd|etcd-metrics)$" || true)
+
+    # Combine and deduplicate
+    all_etcd_services=$(printf "%s\n%s" "${etcd_services}" "${named_services}" | grep -v "^$" | sort -u || true)
+
+    if [ -z "${all_etcd_services}" ]; then
+        log_warn "No etcd services found in kube-system namespace"
+        return 0
+    fi
+
+    service_count=$(echo "${all_etcd_services}" | wc -l | tr -d ' ')
+    log "Found ${service_count} etcd-related service(s) in kube-system"
+
+    # Collect resource definitions for each service
+    echo "${all_etcd_services}" | while IFS= read -r svc_name; do
+        [ -z "${svc_name}" ] && continue
+
+        # Extract service name without 'service/' prefix
+        svc=$(echo "${svc_name}" | sed 's|^service/||')
+        log_debug "Collecting definition for service: ${svc}"
+
+        # Get service definition in YAML format
+        ${CLI} get svc "${svc}" -n kube-system -o yaml \
+            >"${etcd_dir}/${svc}.yaml" 2>&1 ||
+            log_warn "Failed to collect definition for service ${svc}"
+
+        # Get service description
+        ${CLI} describe svc "${svc}" -n kube-system \
+            >"${etcd_dir}/${svc}-describe.txt" 2>&1 ||
+            log_warn "Failed to describe service ${svc}"
+    done
+
+    log "etcd service definitions collected in ${etcd_dir}"
+}
 
 show_usage() {
     cat << EOF
@@ -348,6 +393,9 @@ main() {
     # OpenShift extras
     if [ "${PLATFORM}" = "OpenShift" ]; then
         collect_namespace_data "openshift-controller-manager"
+    # Non-OpenShift extras
+    else
+        collect_etcd_metric_service
     fi
     
     # Create an archive tgz file from the directory


### PR DESCRIPTION
## Why

Currently on non-OCP clusters the ETCD metric visibility relies on ETCD metric service resources.
Instana provides guides on how to create these resources,
but these resource definition are sometimes incorrect. 
In case there is an issue with a feature relying on these resources,
it would greatly help serviceability (especially on SH systems),
if these resources were part of the k8s must gather,
so the correctness of these could be easily verified.

## What

Filter and add matching ETCD metric service resources to the k8s must gather,
based on [currently documented criteria](https://github.com/instana/instana-agent-operator/blob/4482abf657a1b3b4e64814ce081fe933f52544a8/docs/etcd-metrics.md#vanilla-kubernetes-clusters).

## Jira Card

- [INSTA-75604](https://jsw.ibm.com/browse/INSTA-75604)
