### PR TITLE
INSTA-99325: add autotrace-mutating-webhook instrumentation removal script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ This repository contains various scripts and tools designed to assist with **Ins
 
 ## Structure
 
-- **agent/k8s/**  
+- **agent/k8s/**
   Contains Kubernetes/OpenShift–specific scripts (e.g., `instana-k8s-mustgather.sh`) that help gather diagnostic information for Instana Host Agents.
+
+- **autotrace-mutating-webhook/**
+  Contains serviceability scripts for the Instana autotrace mutating webhook, including a script to manually remove instrumentation that was injected by older webhook versions into higher-level workload resources (Deployment, DeploymentConfig, DaemonSet, ReplicaSet, StatefulSet).
 
 As we grow, more directories will be added for different Instana components and environments (including self-hosted Instana) to further enhance serviceability.
 

--- a/autotrace-mutating-webhook/README.md
+++ b/autotrace-mutating-webhook/README.md
@@ -31,7 +31,7 @@ sudo apt-get install jq  # Debian/Ubuntu
 sudo yum install jq      # RHEL/CentOS
 ```
 
-Verify the CLI you intend to use:
+The script auto-detects the CLI: it tries `oc` first and falls back to `kubectl` when `oc` is not available. Confirm at least one is present:
 
 ```bash
 oc whoami                 # OpenShift
@@ -51,30 +51,30 @@ kubectl version --client  # Kubernetes
 |---|---|
 | `--dry-run` | Show what would be removed; no changes made |
 | `--resource TYPE` | One of: `deployment`, `deploymentconfig`, `daemonset`, `replicaset`, `statefulset`, `all` (default: `all`) |
-| `--cli oc\|kubectl` | CLI binary to use (default: `oc`) |
+| `--cli oc\|kubectl` | CLI binary to use (auto-detected: `oc` if present, otherwise `kubectl`) |
 
 > **Note:** `deploymentconfig` is an OpenShift-only resource type and requires `--cli oc`.
 
 ### Examples
 
 ```bash
-# OpenShift — all resource types in a namespace (Deployment, DeploymentConfig, DaemonSet, ReplicaSet, StatefulSet)
+# Auto-detected CLI — all resource types in a namespace
 ./remove-instrumentation.sh test-apps
 
-# OpenShift — dry run first (recommended)
+# Dry run first (recommended)
 ./remove-instrumentation.sh --dry-run test-apps
 
-# OpenShift — specific workload
+# Specific workload
 ./remove-instrumentation.sh test-apps my-app
 
-# OpenShift — only DeploymentConfigs
+# Only DeploymentConfigs (OpenShift)
 ./remove-instrumentation.sh --resource deploymentconfig test-apps
 
-# Kubernetes (plain) — all resource types
+# Force kubectl (plain Kubernetes)
 ./remove-instrumentation.sh --cli kubectl test-apps
 
-# Kubernetes — specific DaemonSet
-./remove-instrumentation.sh --cli kubectl --resource daemonset test-apps my-daemonset
+# Force oc (OpenShift) — specific DaemonSet
+./remove-instrumentation.sh --cli oc --resource daemonset test-apps my-daemonset
 ```
 
 ### What Gets Removed
@@ -214,7 +214,11 @@ The script looks for workloads with the label `instana-autotrace-applied=true`. 
 
 #### "DeploymentConfig is an OpenShift resource and requires --cli oc"
 
-You passed `--resource deploymentconfig` together with `--cli kubectl`. Use `--cli oc` or omit `--cli` (it defaults to `oc`).
+You passed `--resource deploymentconfig` together with `--cli kubectl`. Use `--cli oc` or omit `--cli` (the script will auto-detect `oc` if it is available).
+
+#### "neither 'oc' nor 'kubectl' found in PATH"
+
+Neither CLI binary is available. Install either `oc` (OpenShift) or `kubectl` (Kubernetes) and ensure it is on your `PATH`.
 
 ---
 

--- a/autotrace-mutating-webhook/README.md
+++ b/autotrace-mutating-webhook/README.md
@@ -1,0 +1,223 @@
+# Instana Autotrace Mutating Webhook — Serviceability Scripts
+
+This directory contains serviceability scripts for the **Instana autotrace mutating webhook**.
+
+## Contents
+
+| File | Description |
+|---|---|
+| [`remove-instrumentation.sh`](./remove-instrumentation.sh) | Removes webhook-injected instrumentation from higher-level workload resources (Deployment, DeploymentConfig, DaemonSet, ReplicaSet, StatefulSet) |
+
+---
+
+## Background
+
+Older versions of the Instana autotrace mutating webhook mutated workload objects directly (Deployment, DeploymentConfig, DaemonSet, ReplicaSet, StatefulSet), embedding instrumentation into their specs. The current webhook version mutates only pods, which makes upgrading and removing instrumentation straightforward.
+
+When upgrading from an older webhook version to the current one, the injected fields must first be removed from the higher-level workload resources. A simple redeployment is not always possible in customer environments, so [`remove-instrumentation.sh`](./remove-instrumentation.sh) automates this cleanup safely.
+
+---
+
+## remove-instrumentation.sh
+
+### Prerequisites
+
+```bash
+jq --version   # required
+
+# Install jq if needed
+brew install jq          # macOS
+sudo apt-get install jq  # Debian/Ubuntu
+sudo yum install jq      # RHEL/CentOS
+```
+
+Verify the CLI you intend to use:
+
+```bash
+oc whoami                 # OpenShift
+kubectl version --client  # Kubernetes
+```
+
+### Usage
+
+```bash
+
+./remove-instrumentation.sh [--dry-run] [--resource TYPE] [--cli oc|kubectl] <namespace> [workload-name]
+```
+
+#### Options
+
+| Flag | Description |
+|---|---|
+| `--dry-run` | Show what would be removed; no changes made |
+| `--resource TYPE` | One of: `deployment`, `deploymentconfig`, `daemonset`, `replicaset`, `statefulset`, `all` (default: `all`) |
+| `--cli oc\|kubectl` | CLI binary to use (default: `oc`) |
+
+> **Note:** `deploymentconfig` is an OpenShift-only resource type and requires `--cli oc`.
+
+### Examples
+
+```bash
+# OpenShift — all resource types in a namespace (Deployment, DeploymentConfig, DaemonSet, ReplicaSet, StatefulSet)
+./remove-instrumentation.sh test-apps
+
+# OpenShift — dry run first (recommended)
+./remove-instrumentation.sh --dry-run test-apps
+
+# OpenShift — specific workload
+./remove-instrumentation.sh test-apps my-app
+
+# OpenShift — only DeploymentConfigs
+./remove-instrumentation.sh --resource deploymentconfig test-apps
+
+# Kubernetes (plain) — all resource types
+./remove-instrumentation.sh --cli kubectl test-apps
+
+# Kubernetes — specific DaemonSet
+./remove-instrumentation.sh --cli kubectl --resource daemonset test-apps my-daemonset
+```
+
+### What Gets Removed
+
+The script removes all webhook-added instrumentation from every supported resource type:
+
+- Init containers (`instana-instrumentation-init`)
+- Volumes (`instana-instrumentation-volume`, `instana-autotrace-ace-config-volume`, `instana-autotrace-ibmmq-config-volume`)
+- Volume mounts referencing the above volumes
+- Environment variables (`LD_PRELOAD`, `INSTANA_AGENT_HOST`, `INSTANA_SERVICE_NAME`, `MQ_ENABLE_OPEN_TRACING`, `HOST_IP`, `HOST_ALIAS`, and others)
+- Instana-specific paths stripped from `NODE_OPTIONS` and `PYTHONPATH`
+- Labels (`instana-autotrace-applied`, `instana-autotrace-version`, `instana-autotrace-transformation`) from both the workload and pod template
+- Instana image pull secrets
+
+**Preserved:** your opt-in label (`instana-autotrace: "true"`), all other application env vars, volumes, and image pull secrets.
+
+#### Resource types handled
+
+| Resource | Kubernetes | OpenShift |
+|---|---|---|
+| `Deployment` | ✓ | ✓ |
+| `DeploymentConfig` | — | ✓ |
+| `DaemonSet` | ✓ | ✓ |
+| `ReplicaSet` | ✓ | ✓ |
+| `StatefulSet` | ✓ | ✓ |
+
+> **Not handled by this script:** `Pod` (ephemeral — cleaning the owner resource and triggering a rollout is sufficient) and ingress-nginx `ConfigMap` (different mutation pattern).
+
+### Recommended Workflow
+
+**1 — Confirm instrumentation is present** in the target namespace:
+
+```bash
+# OpenShift
+oc get deployment,deploymentconfig,daemonset,replicaset,statefulset \
+  -n <namespace> -l instana-autotrace-applied=true
+
+# Kubernetes
+kubectl get deployment,daemonset,replicaset,statefulset \
+  -n <namespace> -l instana-autotrace-applied=true
+```
+
+**2 — Dry run first (recommended):**
+
+```bash
+./remove-instrumentation.sh --dry-run <namespace>
+```
+
+Review the output to confirm only the expected fields would be removed.
+
+**3 — Run the removal:**
+
+```bash
+./remove-instrumentation.sh <namespace>
+```
+
+**4 — Verify all workloads are clean:**
+
+```bash
+# OpenShift
+oc get deployment,deploymentconfig,daemonset,replicaset,statefulset \
+  -n <namespace> -o yaml \
+  | grep -E "(LD_PRELOAD|NODE_OPTIONS.*instana|instana-autotrace-applied)"
+
+# Kubernetes
+kubectl get deployment,daemonset,replicaset,statefulset \
+  -n <namespace> -o yaml \
+  | grep -E "(LD_PRELOAD|NODE_OPTIONS.*instana|instana-autotrace-applied)"
+
+# Should return nothing
+```
+
+**5 — Rollback if needed** (backup path is printed by the script):
+
+```bash
+# OpenShift
+oc apply -f ./backups-<timestamp>/<namespace>-<kind>-<name>.yaml
+
+# Kubernetes
+kubectl apply -f ./backups-<timestamp>/<namespace>-<kind>-<name>.yaml
+```
+
+### Important Notes
+
+- The script uses `replace` to avoid cached configuration issues
+- Automatic backups are created in `./backups-<timestamp>/` before any changes; the path is printed at the start of every run
+- The opt-in label (`instana-autotrace: "true"`) is preserved for the new webhook
+- After cleanup, deploy the current webhook version that mutates only pods
+
+### Next Steps
+
+After running this script:
+
+1. Deploy the current webhook version
+2. Restart workloads so the webhook can mutate their pods:
+
+   ```bash
+   # Deployment (Kubernetes or OpenShift)
+   kubectl rollout restart deployment <name> -n <namespace>
+
+   # DaemonSet / StatefulSet
+   kubectl rollout restart daemonset <name> -n <namespace>
+   kubectl rollout restart statefulset <name> -n <namespace>
+
+   # DeploymentConfig (OpenShift only)
+   oc rollout latest deploymentconfig/<name> -n <namespace>
+   ```
+
+3. Verify pods (not workloads) get instrumented:
+
+   ```bash
+   kubectl get pods -n <namespace> -l instana-autotrace-applied=true
+   kubectl describe pod <pod-name> -n <namespace> | grep -A 5 "Init Containers"
+   ```
+
+4. Confirm your application works correctly
+
+### Troubleshooting
+
+#### "jq: command not found"
+
+Install jq using the commands in the Prerequisites section.
+
+#### "No instrumented workloads found"
+
+The script looks for workloads with the label `instana-autotrace-applied=true`. If none are found:
+
+- The webhook may not have run yet — verify pods carry the label
+- Wrong namespace specified
+- Instrumentation was already removed
+
+#### Workload still shows instrumentation after running the script
+
+1. Check the backup file to confirm the original state
+2. Verify no webhook is running: `kubectl get mutatingwebhookconfiguration` (or `oc get mutatingwebhookconfiguration` on OpenShift)
+3. Contact support with the workload YAML
+
+#### "DeploymentConfig is an OpenShift resource and requires --cli oc"
+
+You passed `--resource deploymentconfig` together with `--cli kubectl`. Use `--cli oc` or omit `--cli` (it defaults to `oc`).
+
+---
+
+## Support
+
+For issues or questions, contact your Instana support team.

--- a/autotrace-mutating-webhook/remove-instrumentation.sh
+++ b/autotrace-mutating-webhook/remove-instrumentation.sh
@@ -3,15 +3,17 @@
 # Removes Instana instrumentation injected by the autotrace mutating webhook
 # from Deployment, DeploymentConfig, DaemonSet, ReplicaSet and StatefulSet objects.
 #
-# Use --cli oc  for OpenShift clusters (supports DeploymentConfig, default)
-# Use --cli kubectl for plain Kubernetes clusters
+# By default the script auto-detects the CLI: it tries 'oc' first and falls
+# back to 'kubectl' when 'oc' is not found.
+# Use --cli oc       to force OpenShift CLI (supports DeploymentConfig)
+# Use --cli kubectl  to force plain Kubernetes CLI
 set -e
 
 DRY_RUN=false
 NAMESPACE=""
 WORKLOAD_NAME=""
 RESOURCE_TYPE="all"  # deployment|deploymentconfig|daemonset|replicaset|statefulset|all
-CLI="oc"             # oc | kubectl
+CLI=""               # auto-detected unless --cli is passed
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -46,15 +48,28 @@ if [ -z "$NAMESPACE" ]; then
     echo "  --dry-run                 Show what would be removed without making changes"
     echo "  --resource TYPE           One of: deployment, deploymentconfig, daemonset,"
     echo "                            replicaset, statefulset, all (default: all)"
-    echo "  --cli oc|kubectl          CLI binary to use (default: oc)"
+    echo "  --cli oc|kubectl          CLI binary to use (auto-detected: oc if present, else kubectl)"
     echo ""
     echo "Examples:"
     echo "  $0 test-apps                                   # All resource types in namespace"
     echo "  $0 test-apps my-app                            # Specific workload (all types)"
     echo "  $0 --resource daemonset test-apps              # Only DaemonSets"
-    echo "  $0 --cli kubectl test-apps                     # Use kubectl instead of oc"
+    echo "  $0 --cli kubectl test-apps                     # Force kubectl"
     echo "  $0 --dry-run test-apps                         # Preview without applying"
     exit 1
+fi
+
+# Auto-detect CLI if not explicitly set
+if [ -z "$CLI" ]; then
+    if command -v oc &>/dev/null; then
+        CLI="oc"
+    elif command -v kubectl &>/dev/null; then
+        CLI="kubectl"
+    else
+        echo "ERROR: neither 'oc' nor 'kubectl' found in PATH"
+        exit 1
+    fi
+    echo "Using CLI: $CLI (auto-detected)"
 fi
 
 if [[ "$CLI" != "oc" && "$CLI" != "kubectl" ]]; then

--- a/autotrace-mutating-webhook/remove-instrumentation.sh
+++ b/autotrace-mutating-webhook/remove-instrumentation.sh
@@ -1,0 +1,275 @@
+#!/bin/bash
+
+# Removes Instana instrumentation injected by the autotrace mutating webhook
+# from Deployment, DeploymentConfig, DaemonSet, ReplicaSet and StatefulSet objects.
+#
+# Use --cli oc  for OpenShift clusters (supports DeploymentConfig, default)
+# Use --cli kubectl for plain Kubernetes clusters
+set -e
+
+DRY_RUN=false
+NAMESPACE=""
+WORKLOAD_NAME=""
+RESOURCE_TYPE="all"  # deployment|deploymentconfig|daemonset|replicaset|statefulset|all
+CLI="oc"             # oc | kubectl
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --resource)
+            RESOURCE_TYPE="$2"
+            shift 2
+            ;;
+        --cli)
+            CLI="$2"
+            shift 2
+            ;;
+        *)
+            if [ -z "$NAMESPACE" ]; then
+                NAMESPACE="$1"
+            elif [ -z "$WORKLOAD_NAME" ]; then
+                WORKLOAD_NAME="$1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$NAMESPACE" ]; then
+    echo "Usage: $0 [--dry-run] [--resource TYPE] [--cli oc|kubectl] <namespace> [workload-name]"
+    echo ""
+    echo "Options:"
+    echo "  --dry-run                 Show what would be removed without making changes"
+    echo "  --resource TYPE           One of: deployment, deploymentconfig, daemonset,"
+    echo "                            replicaset, statefulset, all (default: all)"
+    echo "  --cli oc|kubectl          CLI binary to use (default: oc)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 test-apps                                   # All resource types in namespace"
+    echo "  $0 test-apps my-app                            # Specific workload (all types)"
+    echo "  $0 --resource daemonset test-apps              # Only DaemonSets"
+    echo "  $0 --cli kubectl test-apps                     # Use kubectl instead of oc"
+    echo "  $0 --dry-run test-apps                         # Preview without applying"
+    exit 1
+fi
+
+if [[ "$CLI" != "oc" && "$CLI" != "kubectl" ]]; then
+    echo "ERROR: --cli must be 'oc' or 'kubectl' (got: '$CLI')"
+    exit 1
+fi
+
+# DeploymentConfig is an OpenShift-only resource type
+if [[ "$RESOURCE_TYPE" == "deploymentconfig" && "$CLI" == "kubectl" ]]; then
+    echo "ERROR: DeploymentConfig is an OpenShift resource and requires --cli oc"
+    exit 1
+fi
+
+# Create backup directory
+BACKUP_DIR="./backups-$(date +%Y%m%d-%H%M%S)"
+if [ "$DRY_RUN" = false ]; then
+    mkdir -p "$BACKUP_DIR"
+    echo "Backups will be saved to: $BACKUP_DIR"
+else
+    echo "[DRY RUN MODE - No changes will be made]"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# JQ filter — identical for all pod-spec-bearing resource types.
+# Strips every artifact injected by the autotrace webhook.
+# ---------------------------------------------------------------------------
+readonly JQ_FILTER='
+    del(.metadata.annotations."kubectl.kubernetes.io/last-applied-configuration") |
+    del(.metadata.annotations."deployment.kubernetes.io/revision") |
+    if .spec.template.spec.initContainers then
+        .spec.template.spec.initContainers = [.spec.template.spec.initContainers[] | select(.name != "instana-instrumentation-init")] |
+        if (.spec.template.spec.initContainers | length) == 0 then del(.spec.template.spec.initContainers) else . end
+    else . end |
+    if .spec.template.spec.volumes then
+        .spec.template.spec.volumes = [.spec.template.spec.volumes[] |
+            select(
+                .name != "instana-instrumentation-volume" and
+                .name != "instana-autotrace-ace-config-volume" and
+                .name != "instana-autotrace-ibmmq-config-volume"
+            )] |
+        if (.spec.template.spec.volumes | length) == 0 then del(.spec.template.spec.volumes) else . end
+    else . end |
+    .spec.template.spec.containers = [.spec.template.spec.containers[] |
+        if .volumeMounts then
+            .volumeMounts = [.volumeMounts[] |
+                select(
+                    .name != "instana-instrumentation-volume" and
+                    .name != "instana-autotrace-ace-config-volume" and
+                    .name != "instana-autotrace-ibmmq-config-volume"
+                )] |
+            if (.volumeMounts | length) == 0 then del(.volumeMounts) else . end
+        else . end |
+        if .env then
+            .env = [.env[] |
+                if .name == "NODE_OPTIONS" and (.value // "") != "" then
+                    .value = (.value |
+                        gsub("--require /opt/instana/instrumentation/nodejs/node_modules/@instana/collector/src/immediate\\s*"; "") |
+                        gsub("--import /opt/instana/instrumentation/nodejs/node_modules/@instana/collector/esm-register.mjs\\s*"; "") |
+                        gsub("--experimental-loader /opt/instana/instrumentation/nodejs/node_modules/@instana/collector/esm-loader.mjs\\s*"; "") |
+                        gsub("^\\s+|\\s+$"; ""))
+                elif .name == "PYTHONPATH" and (.value // "") != "" then
+                    .value = (.value |
+                        gsub(":/opt/instana/instrumentation/python/custom-site"; "") |
+                        gsub("/opt/instana/instrumentation/python/custom-site:?"; "") |
+                        gsub("^\\s+|\\s+$"; ""))
+                else . end |
+                select(
+                    .name != "LD_PRELOAD" and
+                    .name != "INSTANA_AGENT_HOST" and
+                    .name != "INSTANA_SERVICE_NAME" and
+                    .name != "ACE_ENABLE_OPEN_TRACING" and
+                    .name != "OTEL_TRACING_ENABLED" and
+                    .name != "OTEL_TRACING_PROTOCOL" and
+                    .name != "MQ_ENABLE_OPEN_TRACING" and
+                    .name != "AUTOTRACE_RUBY_HOME" and
+                    .name != "RUBYOPT" and
+                    .name != "INSTANA_TRACER_ENVIRONMENT" and
+                    .name != "INSTANA_ENDPOINT_URL" and
+                    .name != "INSTANA_AGENT_KEY" and
+                    .name != "HOST_ALIAS" and
+                    .name != "HOST_IP"
+                ) |
+                select((.value // "") != "" or .valueFrom != null)
+            ] |
+            if (. | length) == 0 then . = null else . end
+        else . end |
+        if .env == null then del(.env) else . end
+    ] |
+    if .metadata.labels then
+        del(.metadata.labels."instana-autotrace-applied") |
+        del(.metadata.labels."instana-autotrace-version") |
+        del(.metadata.labels."instana-autotrace-transformation")
+    else . end |
+    if .spec.template.metadata.labels then
+        del(.spec.template.metadata.labels."instana-autotrace-applied") |
+        del(.spec.template.metadata.labels."instana-autotrace-version") |
+        del(.spec.template.metadata.labels."instana-autotrace-transformation")
+    else . end |
+    if .spec.template.spec.imagePullSecrets then
+        .spec.template.spec.imagePullSecrets = [.spec.template.spec.imagePullSecrets[] |
+            select((.name | contains("instana")) | not)] |
+        if (.spec.template.spec.imagePullSecrets | length) == 0 then del(.spec.template.spec.imagePullSecrets) else . end
+    else . end |
+    del(.status)
+'
+
+# ---------------------------------------------------------------------------
+# process_workload <kind> <name>
+# ---------------------------------------------------------------------------
+process_workload() {
+    local KIND="$1"
+    local NAME="$2"
+
+    echo "Processing $KIND: $NAME"
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "  [DRY RUN] Would backup $KIND"
+        echo "  [DRY RUN] Would remove:"
+        $CLI get "$KIND" "$NAME" -n "$NAMESPACE" -o yaml \
+            | grep -E "(initContainers:|LD_PRELOAD|MQ_ENABLE_OPEN_TRACING|NODE_OPTIONS.*instana|instana-autotrace-applied|instana-autotrace-version)" \
+            | sed 's/^/    /'
+        echo ""
+        return
+    fi
+
+    # Backup
+    $CLI get "$KIND" "$NAME" -n "$NAMESPACE" -o yaml > "$BACKUP_DIR/${NAMESPACE}-${KIND}-${NAME}.yaml"
+    echo "  ✓ Backed up"
+
+    # Fetch, strip instrumentation, replace
+    $CLI get "$KIND" "$NAME" -n "$NAMESPACE" -o json \
+        | jq "$JQ_FILTER" \
+        | $CLI replace -f - > /dev/null
+
+    echo "  ✓ Removed instrumentation"
+    echo ""
+}
+
+# ---------------------------------------------------------------------------
+# process_kind <kind>
+#   Discovers all instrumented workloads of the given kind (or uses the
+#   explicitly named workload if provided) and calls process_workload.
+# ---------------------------------------------------------------------------
+FOUND_ANY=false
+
+process_kind() {
+    local KIND="$1"
+    local NAMES=""
+
+    # DeploymentConfig is OpenShift-only — skip silently when using kubectl
+    if [[ "$KIND" == "deploymentconfig" && "$CLI" == "kubectl" ]]; then
+        return
+    fi
+
+    if [ -n "$WORKLOAD_NAME" ]; then
+        if $CLI get "$KIND" "$WORKLOAD_NAME" -n "$NAMESPACE" &>/dev/null; then
+            NAMES="$WORKLOAD_NAME"
+        fi
+    else
+        NAMES=$($CLI get "${KIND}s" -n "$NAMESPACE" \
+            -l instana-autotrace-applied=true \
+            -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+    fi
+
+    if [ -n "$NAMES" ]; then
+        FOUND_ANY=true
+        for NAME in $NAMES; do
+            process_workload "$KIND" "$NAME"
+        done
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+case "$RESOURCE_TYPE" in
+    all)
+        process_kind deployment
+        process_kind deploymentconfig
+        process_kind daemonset
+        process_kind replicaset
+        process_kind statefulset
+        ;;
+    deployment|deploymentconfig|daemonset|replicaset|statefulset)
+        process_kind "$RESOURCE_TYPE"
+        ;;
+    *)
+        echo "ERROR: unknown --resource type '$RESOURCE_TYPE'"
+        echo "       Valid values: deployment, deploymentconfig, daemonset, replicaset, statefulset, all"
+        exit 1
+        ;;
+esac
+
+if [ "$FOUND_ANY" = false ]; then
+    echo "No instrumented workloads found in namespace: $NAMESPACE"
+    exit 0
+fi
+
+echo "=========================================="
+echo "Complete!"
+echo "=========================================="
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    echo "This was a dry run. No changes were made."
+    echo ""
+    echo "To apply these changes, run without --dry-run:"
+    echo "  $0 $NAMESPACE${WORKLOAD_NAME:+ $WORKLOAD_NAME}"
+else
+    echo "Backups saved to: $BACKUP_DIR"
+    echo ""
+    echo "Verify workloads are clean:"
+    echo "  $CLI get deployment,daemonset,replicaset,statefulset -n $NAMESPACE -o yaml | grep -E '(LD_PRELOAD|NODE_OPTIONS.*instana|instana-autotrace-applied)'"
+    echo ""
+    echo "To rollback a specific workload:"
+    echo "  $CLI apply -f $BACKUP_DIR/${NAMESPACE}-<kind>-<name>.yaml"
+fi


### PR DESCRIPTION
Older versions of the Instana autotrace mutating webhook mutated workload objects directly (Deployment, DeploymentConfig, DaemonSet, ReplicaSet, StatefulSet), embedding instrumentation into their specs. The current webhook version mutates only pods, which makes upgrading and removing instrumentation straightforward.

When upgrading from an older webhook version to the current one, the injected fields must first be removed from the higher-level workload resources. A simple redeployment is not always possible in customer environments, so [`remove-instrumentation.sh`](./remove-instrumentation.sh) is added to the serviceability repo to automate this cleanup safely.